### PR TITLE
Fixed entityentity and entityattribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ src/.DS_Store
 src/main/.DS_Store
 .classpath
 .project
+.settings/
+.settings
 .settings/org.eclipse.wst.common.component
 src/main/resources/qwanda-services-git.properties

--- a/src/main/java/life/genny/services/BaseEntityService2.java
+++ b/src/main/java/life/genny/services/BaseEntityService2.java
@@ -2183,19 +2183,9 @@ public class BaseEntityService2 {
 	@Transactional
 	public Long updateWithAttributes(BaseEntity entity) {
 
-		try {
-			BaseEntity existing  = this.findBaseEntityByCode(entity.getCode());
-			// merge in entityAttributes
-			entity = getEntityManager().merge(entity);
-            String json = JsonUtils.toJson(entity);
-			writeToDDT(entity.getCode(), json);
-		} catch (final IllegalArgumentException e) {
-			// so persist otherwise
-			getEntityManager().persist(entity);
-			String json = JsonUtils.toJson(entity);
-			writeToDDT(entity.getCode(), json);
+			entity = getEntityManager().merge(entity); 
+ 			writeToDDT(entity);
 
-		}
 		return entity.getId();
 	}
 

--- a/src/main/java/life/genny/services/BaseEntityService2.java
+++ b/src/main/java/life/genny/services/BaseEntityService2.java
@@ -3792,7 +3792,7 @@ public class BaseEntityService2 {
 	public List<BaseEntity> findBaseEntitysByAttributeValues(final MultivaluedMap<String, String> params,
 			final boolean includeAttributes, final Integer pageStart, final Integer pageSize) {
 
-		final List<BaseEntity> eeResults;
+		List<BaseEntity> eeResults= new ArrayList<BaseEntity>();
 		new HashMap<String, BaseEntity>();
 		String realmStr = this.getRealm();
 
@@ -3869,11 +3869,15 @@ public class BaseEntityService2 {
 				}
 				query.setParameter("realmStr", realmStr);
 				query.setFirstResult(pageStart).setMaxResults(pageSize);
-				eeResults = query.getResultList();
+				try {
+					eeResults = query.getResultList();
+				} catch (Exception e) {
+					log.error("findBaseEntitysByAttributeValues Error:"+query.toString());
+				}
 
 			}
 		} else {
-			Log.info("**************** ENTITY ENTITY WITH NO ATTRIBUTES ****************");
+			log.info("**************** ENTITY ENTITY WITH NO ATTRIBUTES ****************");
 
 			eeResults = getEntityManager().createQuery("SELECT be FROM BaseEntity be where be.realm=:realmStr")
 					.setFirstResult(pageStart).setParameter("realmStr", realmStr).setMaxResults(pageSize)

--- a/src/main/java/life/genny/services/BatchLoading.java
+++ b/src/main/java/life/genny/services/BatchLoading.java
@@ -280,7 +280,8 @@ public class BatchLoading {
 		            } catch (final BadDataException e) {
 		              e.printStackTrace();
 		            }
-		            service.updateWithAttributes(be);
+		            be = service.getEntityManager().merge(be);
+		            //service.updateWithAttributes(be);
 		            }
 		          }
 		           catch (final NoResultException e) {
@@ -333,12 +334,13 @@ public class BatchLoading {
           }
           return;
         }
-        sbe.addTarget(tbe, linkAttribute, weight, valueString);
-        service.updateWithAttributes(sbe);
+     //   sbe.addTarget(tbe, linkAttribute, weight, valueString);
+        
+     //   service.updateWithAttributes(sbe);
       } catch (final NoResultException e) {
     	  log.warn("CODE NOT PRESENT IN LINKING: "+parentCode+" : "+targetCode+" : "+linkAttribute);
-      } catch (final BadDataException e) {
-        e.printStackTrace();
+//      } catch (final BadDataException e) {
+//        e.printStackTrace();
       } catch (final NullPointerException e) {
         e.printStackTrace();
       }
@@ -585,7 +587,7 @@ public class BatchLoading {
     BatchLoading.isSynchronise = isSynchronise;
     BatchLoading.table = table;
     if(isSynchronise) {
-      System.out.println("Table to synchronise: " + table);
+      log.info("Table to synchronise: " + table);
       Map<String, Object> finalProject = getProject();
       if(!isDelete) {
         switch(table) {


### PR DESCRIPTION
Transactions breaking within existing transactions (startup) caused grief.
I removed unnecessary merges.
We still need to put back the update entity code that merges in new attributes.